### PR TITLE
Remove js.Lib reference

### DIFF
--- a/src/animateAtlasPlayer/core/Symbol.hx
+++ b/src/animateAtlasPlayer/core/Symbol.hx
@@ -4,7 +4,6 @@ import animateAtlasPlayer.core.AnimationAtlas.Frame;
 import animateAtlasPlayer.core.AnimationAtlas.LayerData;
 import animateAtlasPlayer.core.AnimationAtlas.SymbolData;
 import animateAtlasPlayer.utils.MathUtil;
-import js.Lib;
 import openfl.display.Bitmap;
 import openfl.display.BitmapData;
 import openfl.display.DisplayObject;


### PR DESCRIPTION
We cannot build to another target than html5 for the moment due to the js.Lib importation.