### PR TITLE
Throw an exception when an animation is not found on AssetManager::createAnimation

### DIFF
--- a/src/animateAtlasPlayer/assets/AssetManager.hx
+++ b/src/animateAtlasPlayer/assets/AssetManager.hx
@@ -270,6 +270,9 @@ class AssetManager extends EventDispatcher
 			}
 		}
 
+		if (animation == null)
+			throw 'Animation with name "$name" not found';
+
 		sNames = [];
 		animation.name = name;
 		


### PR DESCRIPTION
To prevent a null reference exception and make the error a little bit more explicit.